### PR TITLE
Added new option to disable SEED only if the table is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ import { SeederModule } from 'nestjs-sequelize-seeder';
          isGlobal: true, // Default: true
          logging: true, // Default: true
          disabled: false, // Default: false
+         runOnlyIfTableIsEmpty: false, // Default: false
          connection: 'default', // Default: default
       }),
    ],
@@ -62,12 +63,13 @@ export class AppModule {}
 
 The **forRoot()** method supports all the configuration properties exposed by the seeder constuctor . In addition, there are several extra configuration properties described below.
 
-| name       | Description                                                                                                                                             | type      |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| isGlobal   | If you want the module globally (**default: _true_** )                                                                                                  | _boolean_ |
-| logging    | Option to display or not, the log of each creation (**default: _true_**)                                                                                | _boolean_ |
-| disabled   | This option allows you to disable the whole module, it is very useful for production mode (**default: _false_**)                                        | _boolean_ |
-| connection | This option is to add the name of the connection, this is very important if you use several connections to different databases (**default: _default_**) | _string_  |
+| name                  | Description                                                                                                                                             | type      |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| isGlobal              | If you want the module globally (**default: _true_** )                                                                                                  | _boolean_ |
+| logging               | Option to display or not, the log of each creation (**default: _true_**)                                                                                | _boolean_ |
+| disabled              | This option allows you to disable the whole module, it is very useful for production mode (**default: _false_**)                                        | _boolean_ |
+| runOnlyIfTableIsEmpty | This option allows you to disable if the table is empty (**default: _false_**)                                                                          | _boolean_ |
+| connection            | This option is to add the name of the connection, this is very important if you use several connections to different databases (**default: _default_**) | _string_  |
 
 ### Seeder
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -18,6 +18,7 @@ export interface SeederModuleOptions {
    isGlobal?: boolean;
    logging?: boolean;
    disabled?: boolean;
+   runOnlyIfTableIsEmpty?: boolean;
    connection?: string;
 }
 
@@ -37,6 +38,7 @@ export const defaultOptions: SeederModuleOptions = {
    isGlobal: true,
    logging: true,
    disabled: false,
+   runOnlyIfTableIsEmpty: false,
    connection: DEFAULT_CONNECTION_NAME,
 };
 

--- a/lib/seed.service.ts
+++ b/lib/seed.service.ts
@@ -72,7 +72,7 @@ export class SeederService {
    private async verifyIfTableIsEmpty(): Promise<boolean> {
       try {
          const data = await this.model.count();
-         if (data === 0) return true;
+         if (data > 0) return true;
          return false;
       } catch (err) {
          throw new Error(`[SeederService] ${err.original.sqlMessage}`);

--- a/lib/seed.service.ts
+++ b/lib/seed.service.ts
@@ -31,6 +31,14 @@ export class SeederService {
          return;
       }
 
+      /**
+       * @author Gabriel Vieira <gabrielvt14@hotmail.com>
+       * @description Execute this if property `runOnlyIfTableIsEmpty` is true
+       */
+      if (this.options.runOnlyIfTableIsEmpty) {
+         if (await this.verifyIfTableIsEmpty()) return;
+      }
+
       // Setting all objects
       this.con = connection;
       this.model = this.con.models[seedData.modelName];
@@ -51,6 +59,20 @@ export class SeederService {
       try {
          const data = await this.model.findOne({ where });
          if (data) return true;
+         return false;
+      } catch (err) {
+         throw new Error(`[SeederService] ${err.original.sqlMessage}`);
+      }
+   }
+
+   /**
+    * @author Gabriel Vieira <gabrielvt14@hotmail.com>
+    * @description Check if the table is empty
+    */
+   private async verifyIfTableIsEmpty(): Promise<boolean> {
+      try {
+         const data = await this.model.count();
+         if (data === 0) return true;
          return false;
       } catch (err) {
          throw new Error(`[SeederService] ${err.original.sqlMessage}`);


### PR DESCRIPTION
I added option runOnlyIfTableIsEmpty.
Receive a boolean.
If true: Run seed only if the table is empty.
If false: Does nothing

The verification of this option is performed only after verification of the disabled option.